### PR TITLE
Add global light and dark theme variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,22 +1,33 @@
 @import "tailwindcss";
 
 :root {
+  /* Light theme */
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #111827; /* near-black for better readability */
+  --muted: #f3f4f6;      /* subtle gray background */
+  --border: #e5e7eb;     /* light border */
+  --primary: #2563eb;    /* accessible blue accent */
+}
+
+.dark {
+  /* Dark theme (applies when .dark class is present on html/body/root) */
+  --background: #0b1220; /* deep navy */
+  --foreground: #e5e7eb; /* light text */
+  --muted: #111827;      /* dark muted background */
+  --border: #1f2937;     /* dark border */
+  --primary: #60a5fa;    /* lighter blue accent for dark mode */
 }
 
 @theme inline {
+  /* Map CSS variables to Tailwind theme tokens/utilities */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-border: var(--border);
+  --color-primary: var(--primary);
+
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {


### PR DESCRIPTION
Updated src/app/globals.css to add global CSS variables for light and dark themes using :root and .dark. Verified locally with pnpm dev.
