### PR TITLE
feat(issue-8): add theme toggle and integrate into navbar (Closes #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "16.1.6",
     "next-auth": "5.0.0-beta.30",
     "next-cloudinary": "^6.17.5",
+    "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       next-cloudinary:
         specifier: ^6.17.5
         version: 6.17.5(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -2227,6 +2230,12 @@ packages:
     peerDependencies:
       next: ^12 || ^13 || ^14 || >=15.0.0-rc || ^15
       react: ^17 || ^18 || >=19.0.0-beta || ^19
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
@@ -4994,6 +5003,11 @@ snapshots:
       '@cloudinary-util/util': 4.0.0
       next: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+
+  next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
+import { ThemeProvider } from "next-themes";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,12 +25,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Navbar />
-        <main>{children}</main>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Navbar />
+          <main>{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,44 +2,63 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import ThemeToggle from "@/components/ThemeToggle";
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
-    <nav className="bg-white shadow-md">
+    <nav className="bg-white shadow-md dark:bg-gray-900 dark:shadow-gray-950/50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16">
+        <div className="flex justify-between items-center h-16">
           {/* Logo */}
-          <div className="flex items-center">
-            <Link href="/" className="text-2xl font-bold text-gray-800">
+          <div className="flex items-center shrink-0">
+            <Link
+              href="/"
+              className="text-2xl font-bold text-gray-800 dark:text-white"
+            >
               Shoreline Woodworks
             </Link>
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8">
-            <Link href="/" className="text-gray-700 hover:text-gray-900">
+          <div className="hidden md:flex items-center flex-1 justify-end space-x-8 pr-4">
+            <Link
+              href="/"
+              className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+            >
               Home
             </Link>
-            <Link href="/projects" className="text-gray-700 hover:text-gray-900">
+            <Link
+              href="/projects"
+              className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+            >
               Projects
             </Link>
-            <Link href="/about" className="text-gray-700 hover:text-gray-900">
+            <Link
+              href="/about"
+              className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+            >
               About
             </Link>
-            <Link href="/contact" className="text-gray-700 hover:text-gray-900">
+            <Link
+              href="/contact"
+              className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+            >
               Contact
             </Link>
           </div>
 
-          {/* Mobile menu button */}
-          <div className="md:hidden flex items-center">
+          {/* Right side: Theme toggle (left of hamburger on mobile, far right on desktop) */}
+          <div className="flex items-center gap-3 shrink-0">
+            <ThemeToggle />
+            {/* Mobile menu button */}
             <button
               type="button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
-              className="text-gray-700 hover:text-gray-900 focus:outline-none"
+              className="md:hidden p-2 text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white focus:outline-none"
               aria-label="Toggle menu"
+              aria-expanded={isMenuOpen}
             >
               <svg
                 className="h-6 w-6"
@@ -63,32 +82,32 @@ export default function Navbar() {
 
       {/* Mobile Navigation */}
       {isMenuOpen && (
-        <div className="md:hidden">
+        <div className="md:hidden border-t border-gray-200 dark:border-gray-700">
           <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
             <Link
               href="/"
-              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 rounded-md"
+              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 rounded-md"
               onClick={() => setIsMenuOpen(false)}
             >
               Home
             </Link>
             <Link
               href="/projects"
-              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 rounded-md"
+              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 rounded-md"
               onClick={() => setIsMenuOpen(false)}
             >
               Projects
             </Link>
             <Link
               href="/about"
-              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 rounded-md"
+              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 rounded-md"
               onClick={() => setIsMenuOpen(false)}
             >
               About
             </Link>
             <Link
               href="/contact"
-              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 rounded-md"
+              className="block px-3 py-2 text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 rounded-md"
               onClick={() => setIsMenuOpen(false)}
             >
               Contact

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useState, useEffect, useRef } from "react";
+
+const THEMES = [
+  { value: "light" as const, label: "Light", icon: SunIcon },
+  { value: "dark" as const, label: "Dark", icon: MoonIcon },
+  { value: "system" as const, label: "System", icon: MonitorIcon },
+] as const;
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const handleSelect = (value: "light" | "dark" | "system") => {
+    setTheme(value);
+    setIsOpen(false);
+  };
+
+  if (!mounted) {
+    return (
+      <div
+        className="h-9 w-9 animate-pulse rounded-lg border border-gray-200 bg-gray-100 dark:border-gray-600 dark:bg-gray-800"
+        aria-hidden
+      />
+    );
+  }
+
+  const selectedTheme = theme ?? "system";
+  const CurrentIcon = THEMES.find((t) => t.value === selectedTheme)?.icon ?? MonitorIcon;
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="rounded-lg border border-gray-200 bg-white p-2 text-gray-600 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+        aria-label="Change theme"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        id="theme-toggle-button"
+      >
+        <CurrentIcon className="h-5 w-5" />
+      </button>
+
+      {isOpen && (
+        <div
+          role="listbox"
+          aria-labelledby="theme-toggle-button"
+          className="absolute right-0 top-full z-50 mt-1 min-w-[10rem] overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+        >
+          {THEMES.map(({ value, label, icon: Icon }) => (
+            <button
+              key={value}
+              type="button"
+              role="option"
+              aria-selected={theme === value}
+              onClick={() => handleSelect(value)}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              <Icon
+                className={`h-4 w-4 shrink-0 ${theme === value ? "text-amber-600 dark:text-amber-400" : ""}`}
+              />
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SunIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+      />
+    </svg>
+  );
+}
+
+function MoonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+      />
+    </svg>
+  );
+}
+
+function MonitorIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
### What this PR does
- Adds a reusable `ThemeToggle` component (`Light`, `Dark`, `System`)  
- Integrates the toggle into `Navbar`  
  - Mobile: left of hamburger menu  
  - Desktop: far right of navbar  
- Wraps the app in `ThemeProvider` inside `layout.tsx` with `class` strategy and `system` default

@darrenmartell and @sarahpoulin, please review this PR.