### PR TITLE
Fixed linting error (didn't really need fixing; just disabling)

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -16,6 +16,7 @@ export default function ThemeToggle() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
   }, []);
 
@@ -69,7 +70,7 @@ export default function ThemeToggle() {
         <div
           role="listbox"
           aria-labelledby="theme-toggle-button"
-          className="absolute right-0 top-full z-50 mt-1 min-w-[10rem] overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+          className="absolute right-0 top-full z-50 mt-1 min-w-40 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
         >
           {THEMES.map(({ value, label, icon: Icon }) => (
             <button


### PR DESCRIPTION
Fixes #53 

react-hooks/set-state-in-effect warns because setting state inside useEffect can cause extra renders or infinite loops. That’s usually true when the effect depends on that state, or it runs repeatedly. This effect:

```typescript
useEffect(() => {
  setMounted(true);
}, []);
```

is safe because it runs exactly once after mount (Empty dependency array). There is also no loop possible because there is no dependency on `mounted`. We also prevent SSR/client mismatch with `suppressHydrationWarning` in `layout.tsx`. So the pattern is essentially:

```typescript
if (!mounted) return skeleton;
```

The fix is just:
```typescript
// eslint-disable-next-line react-hooks/set-state-in-effect
```
which disables the linter for that particular section of code.