### PR TITLE
Potential fix for vercel permissions issue

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -85,7 +85,7 @@ jobs:
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Preview
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --yes --scope=${{ secrets.VERCEL_SCOPE }}
 
 
   deploy-production:
@@ -141,4 +141,4 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Production
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} --yes --scope=${{ secrets.VERCEL_SCOPE }}


### PR DESCRIPTION
Adding this to the vercel deploy commandline should prevent the git author issues
`
--scope=${{ secrets.VERCEL_SCOPE }}
`

I've added my Vercel project as an environment variable (VERCEL_SCOPE) in the GitHub project

Close #69 