### PR TITLE
Feature/admin portal backend

### DIFF
--- a/src/app/api/projects/[id]/__tests__/delete.test.ts
+++ b/src/app/api/projects/[id]/__tests__/delete.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the `DELETE /api/projects/[id]` route handler.
+ *
+ * These tests verify admin-only deletion: auth via verifyAdmin, deletion from
+ * Prisma and optional Cloudinary image cleanup. We mock auth, database, and
+ * Cloudinary so tests run without live services.
+ *
+ * Scenarios covered:
+ * - Success: admin deletes a project; handler removes it from DB and Cloudinary
+ *   (when imagePublicId is set) and returns 200 with { success: true }; second
+ *   delete of same id returns 404.
+ * - Not found: handler returns 404 when the project does not exist.
+ * - Auth: verifyAdmin is called; 401 when session is missing or invalid; 403
+ *   when the user is authenticated but not an admin.
+ * - Server error: handler returns 500 when the database throws (e.g. delete fails).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DELETE } from "../route";
+import { prisma } from "@/lib/db";
+import { verifyAdmin } from "@/lib/auth-guards";
+import { deleteImage } from "@/lib/cloudinary";
+import { mockProjects } from "../../__tests__/fixtures";
+
+// Mock auth guard used by the DELETE handler so we can simulate admin vs
+// unauthenticated/forbidden outcomes.
+vi.mock("@/lib/auth-guards", () => ({
+    verifyAdmin: vi.fn(),
+}));
+
+// Mock Prisma so route tests never depend on a live database.
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        project: {
+            findUnique: vi.fn(),
+            delete: vi.fn(),
+        },
+    },
+}));
+
+// Mock Cloudinary so we avoid real deletions and only assert calls.
+vi.mock("@/lib/cloudinary", () => ({
+    deleteImage: vi.fn(),
+}));
+
+describe("DELETE /api/projects/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * When the project exists and has an image, the handler must delete from both
+     * the database and Cloudinary and return 200 with { success: true }. A second
+     * delete of the same id must return 404 and must not call delete or deleteImage again.
+     */
+    it("should delete a project from both the database and Cloudinary AND second delete of same id returns 404", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const project = mockProjects[0];
+        const projectId = project.id;
+        const params = Promise.resolve({ id: projectId });
+
+        // First call: project exists (has imagePublicId) → delete from DB and Cloudinary, return 200
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(project)
+            .mockResolvedValue(null); // Second call: already deleted → 404
+        (prisma.project.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+        (deleteImage as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+        const req1 = new Request(`http://localhost/api/projects/${projectId}`, {
+            method: "DELETE",
+        });
+        const res1 = await DELETE(req1, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req1, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({ where: { id: projectId } });
+        expect(deleteImage).toHaveBeenCalledWith(project.imagePublicId);
+        expect(prisma.project.delete).toHaveBeenCalledWith({ where: { id: projectId } });
+        expect(res1.status).toBe(200);
+        const body1 = await res1.json();
+        expect(body1).toEqual({ success: true });
+
+        // Second call: same id, project already deleted → 404
+        const req2 = new Request(`http://localhost/api/projects/${projectId}`, {
+            method: "DELETE",
+        });
+        const res2 = await DELETE(req2, { params });
+
+        expect(prisma.project.findUnique).toHaveBeenCalledTimes(2);
+        expect(res2.status).toBe(404);
+        const body2 = await res2.json();
+        expect(body2).toEqual({ error: "Project not found" });
+        // delete and deleteImage must not be called again when project is not found
+        expect(prisma.project.delete).toHaveBeenCalledTimes(1);
+        expect(deleteImage).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * When no project exists for the requested id, the handler must return 404
+     * with a consistent error body and must not call delete or deleteImage.
+     */
+    it("should return 404 when the project does not exist", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const params = Promise.resolve({ id: "nonexistent" });
+        const req = new Request("http://localhost/api/projects/nonexistent", {
+            method: "DELETE",
+        });
+        const res = await DELETE(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: "nonexistent" },
+        });
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Project not found" });
+        expect(prisma.project.delete).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When the session is missing or invalid, verifyAdmin returns a 401 response;
+     * the handler must return that response and must not touch the database or Cloudinary.
+     */
+    it("should return 401 when the session is missing or invalid", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: false,
+            response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+                status: 401,
+            }),
+        });
+
+        const params = Promise.resolve({ id: "1" });
+        const req = new Request("http://localhost/api/projects/1", {
+            method: "DELETE",
+        });
+        const res = await DELETE(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Unauthorized" });
+        expect(prisma.project.findUnique).not.toHaveBeenCalled();
+        expect(prisma.project.delete).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When the user is authenticated but not an admin, verifyAdmin returns 403
+     * Forbidden; the handler must return that response and must not touch the database or Cloudinary.
+     */
+    it("should return 403 when the user is authenticated but NOT an admin", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: false,
+            response: new Response(JSON.stringify({ error: "Forbidden" }), {
+                status: 403,
+                headers: { "Content-Type": "application/json" },
+            }),
+        });
+
+        const params = Promise.resolve({ id: "1" });
+        const req = new Request("http://localhost/api/projects/1", {
+            method: "DELETE",
+        });
+        const res = await DELETE(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Forbidden" });
+        expect(prisma.project.findUnique).not.toHaveBeenCalled();
+        expect(prisma.project.delete).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * If the database throws (e.g. delete fails), the handler catches and returns
+     * 500 with a generic message so we don't leak internal details to the client.
+     */
+    it("should return 500 when something is wrong with the database", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+        const project = mockProjects[0];
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(project);
+        (prisma.project.delete as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new Error("Database connection lost"),
+        );
+        (deleteImage as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+        const params = Promise.resolve({ id: project.id });
+        const req = new Request(`http://localhost/api/projects/${project.id}`, {
+            method: "DELETE",
+        });
+        const res = await DELETE(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: project.id },
+        });
+        expect(deleteImage).toHaveBeenCalledWith(project.imagePublicId);
+        expect(prisma.project.delete).toHaveBeenCalledWith({
+            where: { id: project.id },
+        });
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Failed to delete project" });
+    });
+});

--- a/src/app/api/projects/[id]/__tests__/get.test.ts
+++ b/src/app/api/projects/[id]/__tests__/get.test.ts
@@ -44,7 +44,7 @@ describe("GET /api/projects/[id]", () => {
      */
     it("should return the correct project for each existing id", async () => {
         for (const project of mockProjects) {
-            (prisma.project.findUnique as any).mockResolvedValue(project);
+            (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(project);
 
             const req = new Request(`http://localhost/api/projects/${project.id}`);
             const res = await GET(req, {
@@ -66,7 +66,7 @@ describe("GET /api/projects/[id]", () => {
      * server errors.
      */
     it("should return 404 when the project does not exist", async () => {
-        (prisma.project.findUnique as any).mockResolvedValue(null);
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
         const req = new Request("http://localhost/api/projects/nonexistent");
         const res = await GET(req, {
@@ -87,7 +87,7 @@ describe("GET /api/projects/[id]", () => {
      * details to the client.
      */
     it("should return 500 when the database query fails", async () => {
-        (prisma.project.findUnique as any).mockRejectedValue(
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockRejectedValue(
             new Error("Database connection failed"),
         );
 

--- a/src/app/api/projects/[id]/__tests__/get.test.ts
+++ b/src/app/api/projects/[id]/__tests__/get.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the `GET /api/projects/[id]` route handler.
+ *
+ * These tests verify that a single project is returned by id, and that 404/500
+ * responses are correct. We mock authentication and Prisma so that the tests
+ * focus on how the handler uses the route id and shapes the response.
+ *
+ * Scenarios covered:
+ * - Success: handler returns the project when it exists (for every fixture id).
+ * - Not found: handler returns 404 when Prisma returns null.
+ * - Server error: handler returns 500 when the DB throws or when the route
+ *   params Promise rejects (e.g. framework/routing failure).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../route";
+import { prisma } from "@/lib/db";
+import { mockProjects } from "../../__tests__/fixtures";
+
+// Mock auth to avoid pulling in next-auth/next during tests; the GET [id]
+// handler is public, so auth is irrelevant for these scenarios.
+vi.mock("@/lib/auth", () => ({
+    auth: vi.fn(),
+}));
+
+// Mock the Prisma client so we can control the single project returned
+// (or null for 404) for each test.
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        project: {
+            findUnique: vi.fn(),
+        },
+    },
+}));
+
+describe("GET /api/projects/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * Ensures the handler returns 200 and the correct project body for every
+     * known id. Looping over all mockProjects guards against the handler
+     * e.g. always returning the first project instead of the one matching the id.
+     */
+    it("should return the correct project for each existing id", async () => {
+        for (const project of mockProjects) {
+            (prisma.project.findUnique as any).mockResolvedValue(project);
+
+            const req = new Request(`http://localhost/api/projects/${project.id}`);
+            const res = await GET(req, {
+                params: Promise.resolve({ id: project.id }),
+            });
+
+            expect(prisma.project.findUnique).toHaveBeenCalledWith({
+                where: { id: project.id },
+            });
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toEqual(project);
+        }
+    });
+
+    /**
+     * When no project exists for the requested id, the handler must return 404
+     * with a consistent error body so clients can distinguish "not found" from
+     * server errors.
+     */
+    it("should return 404 when the project does not exist", async () => {
+        (prisma.project.findUnique as any).mockResolvedValue(null);
+
+        const req = new Request("http://localhost/api/projects/nonexistent");
+        const res = await GET(req, {
+            params: Promise.resolve({ id: "nonexistent" }),
+        });
+
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: "nonexistent" },
+        });
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Project not found" });
+    });
+
+    /**
+     * If Prisma throws (e.g. connection lost, constraint error), the handler
+     * catches and returns 500 with a generic message so we don't leak internal
+     * details to the client.
+     */
+    it("should return 500 when the database query fails", async () => {
+        (prisma.project.findUnique as any).mockRejectedValue(
+            new Error("Database connection failed"),
+        );
+
+        const req = new Request("http://localhost/api/projects/1");
+        const res = await GET(req, {
+            params: Promise.resolve({ id: "1" }),
+        });
+
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Failed to fetch project" });
+    });
+
+    /**
+     * Next.js passes route params as a Promise; if that Promise rejects (e.g.
+     * dynamic segment resolution fails), the handler should still return 500
+     * and must not call the database with invalid or missing id.
+     */
+    it("should return 500 when the params promise rejects", async () => {
+        const req = new Request("http://localhost/api/projects/1");
+        const res = await GET(req, {
+            params: Promise.reject(new Error("Route params unavailable")),
+        });
+
+        expect(prisma.project.findUnique).not.toHaveBeenCalled();
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Failed to fetch project" });
+    });
+});

--- a/src/app/api/projects/[id]/__tests__/patch.test.ts
+++ b/src/app/api/projects/[id]/__tests__/patch.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for the `PATCH /api/projects/[id]` route handler.
+ *
+ * These tests verify admin-only update: auth via verifyAdmin, update via Prisma,
+ * and optional Cloudinary upload/delete for image replace or remove. We mock
+ * auth, database, and Cloudinary so tests run without live services.
+ *
+ * Scenarios covered:
+ * - Success: admin updates a project with FormData (e.g. title only); handler
+ *   returns 200 with the updated project.
+ * - Not found: handler returns 404 when the project does not exist.
+ * - Validation: title missing or whitespace-only → 400; invalid image type or
+ *   image over 10MB → 400.
+ * - Auth: 401 when session missing/invalid; 403 when not admin.
+ * - Server error: 500 when the database or (for removeImage) Cloudinary fails.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PATCH } from "../route";
+import { prisma } from "@/lib/db";
+import { verifyAdmin } from "@/lib/auth-guards";
+import { uploadImage, deleteImage } from "@/lib/cloudinary";
+import { mockProjects } from "../../__tests__/fixtures";
+import type { ProjectApiResponse } from "@/types/project";
+
+// Mock auth guard used by the PATCH handler so we can simulate admin vs
+// unauthenticated/forbidden outcomes.
+vi.mock("@/lib/auth-guards", () => ({
+    verifyAdmin: vi.fn(),
+}));
+
+// Mock Prisma so route tests never depend on a live database.
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        project: {
+            findUnique: vi.fn(),
+            update: vi.fn(),
+        },
+    },
+}));
+
+// Mock Cloudinary so we avoid real uploads/deletions and only assert calls.
+vi.mock("@/lib/cloudinary", () => ({
+    uploadImage: vi.fn(),
+    deleteImage: vi.fn(),
+}));
+
+describe("PATCH /api/projects/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * When the project exists and the admin sends valid FormData (e.g. title only),
+     * the handler must call update with the correct data and return 200 with the
+     * updated project. No image upload or delete is involved when only fields like
+     * title are sent.
+     */
+    it("should return 200 with the updated project when the project was successfully updated", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const existing = mockProjects[0];
+        const updatedProject: ProjectApiResponse = {
+            ...existing,
+            title: "Updated Title",
+            updatedAt: "2026-02-12T12:00:00.000Z",
+        };
+
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+        (prisma.project.update as ReturnType<typeof vi.fn>).mockResolvedValue(updatedProject);
+
+        const formData = new FormData();
+        formData.set("title", "Updated Title   ");
+
+        const params = Promise.resolve({ id: existing.id });
+        const req = new Request(`http://localhost/api/projects/${existing.id}`, {
+            method: "PATCH",
+            body: formData,
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: existing.id },
+        });
+        expect(prisma.project.update).toHaveBeenCalledWith({
+            where: { id: existing.id },
+            data: {
+                title: "Updated Title",
+                description: existing.description,
+                category: existing.category,
+                featured: existing.featured,
+                imageUrl: existing.imageUrl,
+                imagePublicId: existing.imagePublicId,
+            },
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toEqual(updatedProject);
+        expect(body.title).toBe(updatedProject.title.trim());
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When FormData is invalid because title is missing from the payload, the
+     * handler must return 400 with { error: "Title is required" } and must not
+     * call update, uploadImage, or deleteImage.
+     */
+    it("should return 400 when title is missing from the payload", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const existing = mockProjects[0];
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+
+        const formData = new FormData();
+        formData.set("description", "Only description, no title");
+
+        const params = Promise.resolve({ id: existing.id });
+        const req = new Request(`http://localhost/api/projects/${existing.id}`, {
+            method: "PATCH",
+            body: formData,
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: existing.id },
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Title is required" });
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When the title field is set but is only whitespace, the handler must return
+     * 400 with { error: "Title is required" } and must not call update, uploadImage,
+     * or deleteImage.
+     */
+    it("should return 400 when title is set but is only whitespace", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const existing = mockProjects[0];
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+
+        const formData = new FormData();
+        formData.set("title", "   ");
+
+        const params = Promise.resolve({ id: existing.id });
+        const req = new Request(`http://localhost/api/projects/${existing.id}`, {
+            method: "PATCH",
+            body: formData,
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: existing.id },
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Title is required" });
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When a new image is provided but its size is greater than 10MB, the handler
+     * must return 400 with the size-limit error and must not call uploadImage or update.
+     */
+    it("should return 400 when the image file is greater than 10MB", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const existing = mockProjects[0];
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+
+        const largeFile = new File(
+            [new ArrayBuffer(10 * 1024 * 1024 + 1)],
+            "large.jpg",
+            { type: "image/jpeg" },
+        );
+
+        const fakeFormData = {
+            get(key: string): string | File | null {
+                if (key === "title") return "Valid Title";
+                if (key === "image") return largeFile;
+                return null;
+            },
+        };
+
+        const params = Promise.resolve({ id: existing.id });
+        const req = {
+            formData: async () => fakeFormData,
+        } as unknown as Request;
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: existing.id },
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Image file is too large (max 10MB)" });
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Only allowed image types (jpeg, jpg, png, webp, gif) are accepted when
+     * updating the project image. An unsupported MIME type (e.g. image/svg+xml)
+     * must be rejected with 400 and the documented allowed-types error message;
+     * uploadImage and update must not be called.
+     */
+    it("should return 400 when the image has an unsupported MIME type", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const existing = mockProjects[0];
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+
+        const svgFile = new File(
+            [new ArrayBuffer(1)],
+            "image.svg",
+            { type: "image/svg+xml" },
+        );
+
+        const fakeFormData = {
+            get(key: string): string | File | null {
+                if (key === "title") return "Valid Title";
+                if (key === "image") return svgFile;
+                return null;
+            },
+        };
+
+        const params = Promise.resolve({ id: existing.id });
+        const req = {
+            formData: async () => fakeFormData,
+        } as unknown as Request;
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: existing.id },
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body).toEqual({
+            error:
+                "Invalid image type. Allowed: image/jpeg, image/jpg, image/png, image/webp, image/gif",
+        });
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When no project exists for the requested id, the handler must return 404
+     * with a consistent error body and must not call update, uploadImage, or deleteImage.
+     */
+    it("should return 404 when the project does not exist", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const formData = new FormData();
+        formData.set("title", "Some Title");
+
+        const params = Promise.resolve({ id: "nonexistent" });
+        const req = new Request("http://localhost/api/projects/nonexistent", {
+            method: "PATCH",
+            body: formData,
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: "nonexistent" },
+        });
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Project not found" });
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When the session is missing or invalid, verifyAdmin returns a 401 response;
+     * the handler must return that response and must not touch the database or Cloudinary.
+     */
+    it("should return 401 when the session is missing or invalid", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: false,
+            response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+                status: 401,
+            }),
+        });
+
+        const params = Promise.resolve({ id: "1" });
+        const req = new Request("http://localhost/api/projects/1", {
+            method: "PATCH",
+            body: new FormData(),
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Unauthorized" });
+        expect(prisma.project.findUnique).not.toHaveBeenCalled();
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * When the user is authenticated but not an admin, verifyAdmin returns 403
+     * Forbidden; the handler must return that response and must not touch the database or Cloudinary.
+     */
+    it("should return 403 when the user is authenticated but NOT an admin", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: false,
+            response: new Response(JSON.stringify({ error: "Forbidden" }), {
+                status: 403,
+                headers: { "Content-Type": "application/json" },
+            }),
+        });
+
+        const params = Promise.resolve({ id: "1" });
+        const req = new Request("http://localhost/api/projects/1", {
+            method: "PATCH",
+            body: new FormData(),
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Forbidden" });
+        expect(prisma.project.findUnique).not.toHaveBeenCalled();
+        expect(prisma.project.update).not.toHaveBeenCalled();
+        expect(uploadImage).not.toHaveBeenCalled();
+        expect(deleteImage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * If the database throws (e.g. update fails), the handler catches and returns
+     * 500 with a generic message so we don't leak internal details to the client.
+     */
+    it("should return 500 when there is an issue with the database", async () => {
+        (verifyAdmin as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ok: true,
+            user: { isAdmin: true },
+        });
+
+        const existing = mockProjects[0];
+        (prisma.project.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+        (prisma.project.update as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new Error("Database connection lost"),
+        );
+
+        const formData = new FormData();
+        formData.set("title", "Updated Title");
+
+        const params = Promise.resolve({ id: existing.id });
+        const req = new Request(`http://localhost/api/projects/${existing.id}`, {
+            method: "PATCH",
+            body: formData,
+        });
+        const res = await PATCH(req, { params });
+
+        expect(verifyAdmin).toHaveBeenCalledWith(req, { params });
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+            where: { id: existing.id },
+        });
+        expect(prisma.project.update).toHaveBeenCalled();
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body).toEqual({ error: "Failed to update project" });
+    });
+});

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,0 +1,160 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth-guards";
+import { deleteImage, replaceProjectImage } from "@/lib/cloudinary";
+
+export const runtime = "nodejs";
+
+type RouteParams = {
+  params: {
+    id: string;
+  };
+};
+
+export async function GET(_req: Request, { params }: RouteParams) {
+  try {
+    const project = await prisma.project.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!project) {
+      return NextResponse.json(
+        { error: "Project not found" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ data: project });
+  } catch (error) {
+    console.error("Failed to fetch project", error);
+    return NextResponse.json(
+      { error: "Failed to fetch project" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(req: Request, { params }: RouteParams) {
+  const adminResult = await requireAdmin();
+  if (!adminResult.ok) {
+    return adminResult.response;
+  }
+
+  try {
+    const existing = await prisma.project.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Project not found" },
+        { status: 404 },
+      );
+    }
+
+    const formData = await req.formData();
+
+    const title = formData.get("title");
+    const description = formData.get("description");
+    const category = formData.get("category");
+    const featured = formData.get("featured");
+    const image = formData.get("image");
+
+    let imageUrl = existing.imageUrl;
+    let imagePublicId = existing.imagePublicId;
+
+    if (image instanceof File) {
+      if (!image.type.startsWith("image/")) {
+        return NextResponse.json(
+          { error: "Image must be of type image/*" },
+          { status: 400 },
+        );
+      }
+
+      const maxSizeBytes = 5 * 1024 * 1024;
+      if (image.size > maxSizeBytes) {
+        return NextResponse.json(
+          { error: "Image file is too large (max 5MB)" },
+          { status: 400 },
+        );
+      }
+
+      const buffer = Buffer.from(await image.arrayBuffer());
+      const uploaded = await replaceProjectImage(existing.imagePublicId, buffer);
+
+      imageUrl = uploaded.secureUrl;
+      imagePublicId = uploaded.publicId;
+    }
+
+    const updated = await prisma.project.update({
+      where: { id: params.id },
+      data: {
+        title:
+          typeof title === "string" && title.length > 0
+            ? title
+            : existing.title,
+        description:
+          typeof description === "string"
+            ? description
+            : existing.description,
+        category:
+          typeof category === "string" ? category : existing.category,
+        featured:
+          typeof featured === "string"
+            ? featured === "true"
+            : existing.featured,
+        imageUrl,
+        imagePublicId,
+      },
+    });
+
+    return NextResponse.json({ data: updated });
+  } catch (error) {
+    console.error("Failed to update project", error);
+    return NextResponse.json(
+      { error: "Failed to update project" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(_req: Request, { params }: RouteParams) {
+  const adminResult = await requireAdmin();
+  if (!adminResult.ok) {
+    return adminResult.response;
+  }
+
+  try {
+    const existing = await prisma.project.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Project not found" },
+        { status: 404 },
+      );
+    }
+
+    await prisma.project.delete({
+      where: { id: params.id },
+    });
+
+    if (existing.imagePublicId) {
+      try {
+        await deleteImage(existing.imagePublicId);
+      } catch (error) {
+        console.error("Failed to delete project image in Cloudinary", error);
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete project", error);
+    return NextResponse.json(
+      { error: "Failed to delete project" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -40,7 +40,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
 
     return NextResponse.json(project);
   } catch (error) {
-    console.error("Failed to fetch project", error);
+    //console.error("Failed to fetch project", error);
     return NextResponse.json(
       { error: "Failed to fetch project" },
       { status: 500 },
@@ -85,6 +85,20 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     const image = formData.get("image");
     const removeImage = formData.get("removeImage");
 
+    if (!title || typeof title !== "string") {
+      return NextResponse.json(
+        { error: "Title is required" },
+        { status: 400 },
+      );
+    }
+    const titleTrimmed = title.trim();
+    if (!titleTrimmed) {
+      return NextResponse.json(
+        { error: "Title is required" },
+        { status: 400 },
+      );
+    }
+
     let imageUrl: string | null = existing.imageUrl;
     let imagePublicId: string | null = existing.imagePublicId;
 
@@ -121,7 +135,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
           imageUrl = null;
           imagePublicId = null;
         } catch (error) {
-          console.error("Failed to delete project image in Cloudinary", error);
+          //console.error("Failed to delete project image in Cloudinary", error);
           return NextResponse.json(
             { error: "Failed to delete existing image" },
             { status: 500 },
@@ -137,10 +151,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     const updated = await prisma.project.update({
       where: { id },
       data: {
-        title:
-          typeof title === "string" && title.trim().length > 0
-            ? title.trim()
-            : existing.title,
+        title: titleTrimmed,
         description:
           typeof description === "string"
             ? (description.trim() || null)
@@ -163,20 +174,20 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       try {
         await deleteImage(existing.imagePublicId);
       } catch (error) {
-        console.error("Failed to delete old project image in Cloudinary after update", error);
+        //console.error("Failed to delete old project image in Cloudinary after update", error);
       }
     }
 
     return NextResponse.json(updated);
   } catch (error) {
-    console.error("Failed to update project", error);
+    //console.error("Failed to update project", error);
 
     // Best-effort cleanup if a new image was uploaded but the DB update failed.
     if (newUploadedPublicId) {
       try {
         await deleteImage(newUploadedPublicId);
       } catch (cleanupError) {
-        console.error("Failed to cleanup newly uploaded image after DB error", cleanupError);
+        //console.error("Failed to cleanup newly uploaded image after DB error", cleanupError);
       }
     }
 
@@ -216,7 +227,7 @@ export async function DELETE(req: Request, { params }: RouteParams) {
       try {
         await deleteImage(existing.imagePublicId);
       } catch (error) {
-        console.error("Failed to delete project image in Cloudinary", error);
+        //console.error("Failed to delete project image in Cloudinary", error);
       }
     }
 
@@ -226,7 +237,7 @@ export async function DELETE(req: Request, { params }: RouteParams) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error("Failed to delete project", error);
+    //console.error("Failed to delete project", error);
     return NextResponse.json(
       { error: "Failed to delete project" },
       { status: 500 },

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,20 +1,30 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { requireAdmin } from "@/lib/auth-guards";
+import { verifyAdmin } from "@/lib/auth-guards";
 import { deleteImage, replaceProjectImage } from "@/lib/cloudinary";
 
 export const runtime = "nodejs";
 
+const ALLOWED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
+
+const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
 type RouteParams = {
-  params: {
-    id: string;
-  };
+  params: Promise<{ id: string }>;
 };
 
+/** Public: no authentication required. Returns a single project by id or 404. */
 export async function GET(_req: Request, { params }: RouteParams) {
   try {
+    const { id } = await params;
     const project = await prisma.project.findUnique({
-      where: { id: params.id },
+      where: { id },
     });
 
     if (!project) {
@@ -24,7 +34,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
       );
     }
 
-    return NextResponse.json({ data: project });
+    return NextResponse.json(project);
   } catch (error) {
     console.error("Failed to fetch project", error);
     return NextResponse.json(
@@ -34,15 +44,22 @@ export async function GET(_req: Request, { params }: RouteParams) {
   }
 }
 
+/**
+ * Admin only. Accepts multipart/form-data with optional fields:
+ * title, description, category (strings), featured ("true"/"false"),
+ * image (File), removeImage ("true" to remove image without replacement).
+ * Returns the full updated project object on success.
+ */
 export async function PATCH(req: Request, { params }: RouteParams) {
-  const adminResult = await requireAdmin();
+  const { id } = await params;
+  const adminResult = await verifyAdmin(req, { params });
   if (!adminResult.ok) {
     return adminResult.response;
   }
 
   try {
     const existing = await prisma.project.findUnique({
-      where: { id: params.id },
+      where: { id },
     });
 
     if (!existing) {
@@ -53,52 +70,64 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     }
 
     const formData = await req.formData();
-
     const title = formData.get("title");
     const description = formData.get("description");
     const category = formData.get("category");
     const featured = formData.get("featured");
     const image = formData.get("image");
+    const removeImage = formData.get("removeImage");
 
-    let imageUrl = existing.imageUrl;
-    let imagePublicId = existing.imagePublicId;
+    let imageUrl: string | null = existing.imageUrl;
+    let imagePublicId: string | null = existing.imagePublicId;
 
-    if (image instanceof File) {
-      if (!image.type.startsWith("image/")) {
+    if (removeImage === "true" && existing.imagePublicId) {
+      try {
+        await deleteImage(existing.imagePublicId);
+      } catch (error) {
+        console.error("Failed to delete project image in Cloudinary", error);
+      }
+      imageUrl = null;
+      imagePublicId = null;
+    }
+
+    if (image instanceof File && image.size > 0) {
+      if (!ALLOWED_IMAGE_TYPES.has(image.type)) {
         return NextResponse.json(
-          { error: "Image must be of type image/*" },
+          {
+            error:
+              "Invalid image type. Allowed: image/jpeg, image/jpg, image/png, image/webp, image/gif",
+          },
           { status: 400 },
         );
       }
-
-      const maxSizeBytes = 5 * 1024 * 1024;
-      if (image.size > maxSizeBytes) {
+      if (image.size > MAX_IMAGE_SIZE_BYTES) {
         return NextResponse.json(
-          { error: "Image file is too large (max 5MB)" },
+          { error: "Image file is too large (max 10MB)" },
           { status: 400 },
         );
       }
 
       const buffer = Buffer.from(await image.arrayBuffer());
       const uploaded = await replaceProjectImage(existing.imagePublicId, buffer);
-
       imageUrl = uploaded.secureUrl;
       imagePublicId = uploaded.publicId;
     }
 
     const updated = await prisma.project.update({
-      where: { id: params.id },
+      where: { id },
       data: {
         title:
-          typeof title === "string" && title.length > 0
-            ? title
+          typeof title === "string" && title.trim().length > 0
+            ? title.trim()
             : existing.title,
         description:
           typeof description === "string"
-            ? description
+            ? (description.trim() || null)
             : existing.description,
         category:
-          typeof category === "string" ? category : existing.category,
+          typeof category === "string"
+            ? (category.trim() || null)
+            : existing.category,
         featured:
           typeof featured === "string"
             ? featured === "true"
@@ -108,7 +137,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       },
     });
 
-    return NextResponse.json({ data: updated });
+    return NextResponse.json(updated);
   } catch (error) {
     console.error("Failed to update project", error);
     return NextResponse.json(
@@ -118,15 +147,20 @@ export async function PATCH(req: Request, { params }: RouteParams) {
   }
 }
 
-export async function DELETE(_req: Request, { params }: RouteParams) {
-  const adminResult = await requireAdmin();
+/**
+ * Admin only. Deletes the project and its Cloudinary image (if any).
+ * Process: verify admin → fetch project → 404 if not found → delete image from Cloudinary (best effort) → delete project → return success.
+ */
+export async function DELETE(req: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const adminResult = await verifyAdmin(req, { params });
   if (!adminResult.ok) {
     return adminResult.response;
   }
 
   try {
     const existing = await prisma.project.findUnique({
-      where: { id: params.id },
+      where: { id },
     });
 
     if (!existing) {
@@ -136,10 +170,6 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
       );
     }
 
-    await prisma.project.delete({
-      where: { id: params.id },
-    });
-
     if (existing.imagePublicId) {
       try {
         await deleteImage(existing.imagePublicId);
@@ -147,6 +177,10 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
         console.error("Failed to delete project image in Cloudinary", error);
       }
     }
+
+    await prisma.project.delete({
+      where: { id },
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/projects/__tests__/fixtures.ts
+++ b/src/app/api/projects/__tests__/fixtures.ts
@@ -1,0 +1,73 @@
+import type { ProjectApiResponse } from "@/types/project";
+
+/**
+ * Shared mock project data for API route tests (GET list, GET by id, etc.).
+ * Use this instead of defining inline fixtures in each test file.
+ */
+export const mockProjects: ProjectApiResponse[] = [
+  {
+    id: "1",
+    title: "Oak Floor Refinishing - Downtown Condo",
+    description:
+      "Complete sanding and refinishing of original oak hardwood floors in a downtown residential condo.",
+    category: "Residential",
+    featured: true,
+    imageUrl:
+      "https://res.cloudinary.com/demo/image/upload/v1738791001/shoreline/projects/oak-condo.jpg",
+    imagePublicId: "shoreline/projects/oak-condo",
+    createdAt: "2026-02-06T10:15:00.000Z",
+    updatedAt: "2026-02-06T10:15:00.000Z",
+  },
+  {
+    id: "2",
+    title: "Maple Hardwood Installation - Family Home",
+    description:
+      "Installed new maple hardwood flooring throughout the main floor of a detached family home.",
+    category: "Residential",
+    featured: false,
+    imageUrl:
+      "https://res.cloudinary.com/demo/image/upload/v1738791201/shoreline/projects/maple-install.jpg",
+    imagePublicId: "shoreline/projects/maple-install",
+    createdAt: "2026-02-05T14:30:00.000Z",
+    updatedAt: "2026-02-05T14:30:00.000Z",
+  },
+  {
+    id: "3",
+    title: "Staircase Sanding & Staining",
+    description:
+      "Refinished residential staircase including sanding, staining, and protective polyurethane coating.",
+    category: "Residential",
+    featured: false,
+    imageUrl:
+      "https://res.cloudinary.com/demo/image/upload/v1738791401/shoreline/projects/staircase.jpg",
+    imagePublicId: "shoreline/projects/staircase",
+    createdAt: "2026-02-04T09:45:00.000Z",
+    updatedAt: "2026-02-04T09:45:00.000Z",
+  },
+  {
+    id: "4",
+    title: "Commercial Showroom Flooring",
+    description:
+      "Installed durable engineered hardwood flooring in a high-traffic commercial showroom space.",
+    category: "Commercial",
+    featured: false,
+    imageUrl:
+      "https://res.cloudinary.com/demo/image/upload/v1738791601/shoreline/projects/showroom.jpg",
+    imagePublicId: "shoreline/projects/showroom",
+    createdAt: "2026-02-03T16:20:00.000Z",
+    updatedAt: "2026-02-03T16:20:00.000Z",
+  },
+  {
+    id: "5",
+    title: "Gymnasium Floor Restoration",
+    description:
+      "Full restoration and sealing of a school gymnasium hardwood sports floor.",
+    category: "Institutional",
+    featured: false,
+    imageUrl:
+      "https://res.cloudinary.com/demo/image/upload/v1738791801/shoreline/projects/gym-floor.jpg",
+    imagePublicId: "shoreline/projects/gym-floor",
+    createdAt: "2026-02-02T11:10:00.000Z",
+    updatedAt: "2026-02-02T11:10:00.000Z",
+  },
+];

--- a/src/app/api/projects/__tests__/get.test.ts
+++ b/src/app/api/projects/__tests__/get.test.ts
@@ -46,7 +46,7 @@ describe("GET /api/projects", () => {
      * order by createdAt desc so the response is the full list in the correct order.
      */
     it("should return a list of projects with no filters", async () => {
-        (prisma.project.findMany as any).mockResolvedValue(mockProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(mockProjects);
 
         const req = new Request("http://localhost/api/projects");
         const res = await GET(req);
@@ -68,7 +68,7 @@ describe("GET /api/projects", () => {
         const residentialProjects = mockProjects.filter(
             (project: ProjectApiResponse) => project.category === "Residential",
         );
-        (prisma.project.findMany as any).mockResolvedValue(residentialProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(residentialProjects);
 
         const req = new Request("http://localhost/api/projects?category=Residential");
         const res = await GET(req);
@@ -95,7 +95,7 @@ describe("GET /api/projects", () => {
         const featuredProjects = mockProjects.filter(
             (project: ProjectApiResponse) => project.featured,
         );
-        (prisma.project.findMany as any).mockResolvedValue(featuredProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(featuredProjects);
 
         const req = new Request("http://localhost/api/projects?featured=true");
         const res = await GET(req);
@@ -120,7 +120,7 @@ describe("GET /api/projects", () => {
         const nonFeaturedProjects = mockProjects.filter(
             (project: ProjectApiResponse) => !project.featured,
         );
-        (prisma.project.findMany as any).mockResolvedValue(nonFeaturedProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(nonFeaturedProjects);
 
         const req = new Request("http://localhost/api/projects?featured=false");
         const res = await GET(req);
@@ -142,7 +142,7 @@ describe("GET /api/projects", () => {
      * 500 with a generic message so we don't leak internal details to the client.
      */
     it("should return a 500 error if the database query fails", async () => {
-        (prisma.project.findMany as any).mockRejectedValue(new Error("Database query failed"));
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Database query failed"));
 
         const req = new Request("http://localhost/api/projects");
         const res = await GET(req);
@@ -160,7 +160,7 @@ describe("GET /api/projects", () => {
             (project: ProjectApiResponse) =>
                 project.category === "Residential" && project.featured === true,
         );
-        (prisma.project.findMany as any).mockResolvedValue(featuredResidentialProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(featuredResidentialProjects);
 
         const req = new Request(
             "http://localhost/api/projects?category=Residential&featured=true",
@@ -186,7 +186,7 @@ describe("GET /api/projects", () => {
      * empty array (not 404 or 500) so clients can distinguish "no results" from errors.
      */
     it("should return an empty array when no projects match the filters", async () => {
-        (prisma.project.findMany as any).mockResolvedValue([]);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
         const req = new Request("http://localhost/api/projects?category=NonExistent");
         const res = await GET(req);
@@ -210,7 +210,7 @@ describe("GET /api/projects", () => {
         const nonFeaturedProjects = mockProjects.filter(
             (project: ProjectApiResponse) => !project.featured,
         );
-        (prisma.project.findMany as any).mockResolvedValue(nonFeaturedProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(nonFeaturedProjects);
 
         const req = new Request("http://localhost/api/projects?featured=invalid");
         const res = await GET(req);
@@ -230,7 +230,7 @@ describe("GET /api/projects", () => {
      * handler should use an empty where so the full list is returned.
      */
     it("should ignore empty category parameter", async () => {
-        (prisma.project.findMany as any).mockResolvedValue(mockProjects);
+        (prisma.project.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(mockProjects);
 
         const req = new Request("http://localhost/api/projects?category=");
         const res = await GET(req);

--- a/src/app/api/projects/__tests__/get.test.ts
+++ b/src/app/api/projects/__tests__/get.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the `GET /api/projects` route handler.
+ *
+ * These tests verify filtering, ordering, and error behavior of the projects
+ * listing endpoint. We mock authentication and Prisma so that the tests focus
+ * purely on how the handler builds its Prisma query and shapes the response.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../route";
+import { prisma } from "@/lib/db";
+import type { ProjectApiResponse } from "@/types/project";
+
+// Mock auth to avoid pulling in next-auth/next during tests; the GET handler
+// is public, so auth is irrelevant for these scenarios.
+vi.mock("@/lib/auth", () => ({
+    auth: vi.fn(),
+}));
+
+// Mock the Prisma client so we can precisely control the projects returned
+// for each combination of query-string filters.
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        project: {
+            findMany: vi.fn(),
+        },
+    },
+}));
+
+describe("GET /api/projects", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    // Mock projects data for testing
+    const mockProjects: ProjectApiResponse[] = [
+        {
+            id: "1",
+            title: "Oak Floor Refinishing - Downtown Condo",
+            description:
+                "Complete sanding and refinishing of original oak hardwood floors in a downtown residential condo.",
+            category: "Residential",
+            featured: true,
+            imageUrl:
+                "https://res.cloudinary.com/demo/image/upload/v1738791001/shoreline/projects/oak-condo.jpg",
+            imagePublicId: "shoreline/projects/oak-condo",
+            createdAt: "2026-02-06T10:15:00.000Z",
+            updatedAt: "2026-02-06T10:15:00.000Z",
+        },
+        {
+            id: "2",
+            title: "Maple Hardwood Installation - Family Home",
+            description:
+                "Installed new maple hardwood flooring throughout the main floor of a detached family home.",
+            category: "Residential",
+            featured: false,
+            imageUrl:
+                "https://res.cloudinary.com/demo/image/upload/v1738791201/shoreline/projects/maple-install.jpg",
+            imagePublicId: "shoreline/projects/maple-install",
+            createdAt: "2026-02-05T14:30:00.000Z",
+            updatedAt: "2026-02-05T14:30:00.000Z",
+        },
+        {
+            id: "3",
+            title: "Staircase Sanding & Staining",
+            description:
+                "Refinished residential staircase including sanding, staining, and protective polyurethane coating.",
+            category: "Residential",
+            featured: false,
+            imageUrl:
+                "https://res.cloudinary.com/demo/image/upload/v1738791401/shoreline/projects/staircase.jpg",
+            imagePublicId: "shoreline/projects/staircase",
+            createdAt: "2026-02-04T09:45:00.000Z",
+            updatedAt: "2026-02-04T09:45:00.000Z",
+        },
+        {
+            id: "4",
+            title: "Commercial Showroom Flooring",
+            description:
+                "Installed durable engineered hardwood flooring in a high-traffic commercial showroom space.",
+            category: "Commercial",
+            featured: false,
+            imageUrl:
+                "https://res.cloudinary.com/demo/image/upload/v1738791601/shoreline/projects/showroom.jpg",
+            imagePublicId: "shoreline/projects/showroom",
+            createdAt: "2026-02-03T16:20:00.000Z",
+            updatedAt: "2026-02-03T16:20:00.000Z",
+        },
+        {
+            id: "5",
+            title: "Gymnasium Floor Restoration",
+            description:
+                "Full restoration and sealing of a school gymnasium hardwood sports floor.",
+            category: "Institutional",
+            featured: false,
+            imageUrl:
+                "https://res.cloudinary.com/demo/image/upload/v1738791801/shoreline/projects/gym-floor.jpg",
+            imagePublicId: "shoreline/projects/gym-floor",
+            createdAt: "2026-02-02T11:10:00.000Z",
+            updatedAt: "2026-02-02T11:10:00.000Z",
+        },
+    ];
+
+    it("should return a list of projects with no filters", async () => {
+        (prisma.project.findMany as any).mockResolvedValue(mockProjects);
+
+        const req = new Request("http://localhost/api/projects");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: {},
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(body).toEqual(mockProjects);
+    });
+
+    it("should return a list of projects filtered by category", async () => {
+        const residentialProjects = mockProjects.filter(
+            (project: ProjectApiResponse) => project.category === "Residential",
+        );
+        (prisma.project.findMany as any).mockResolvedValue(residentialProjects);
+
+        const req = new Request("http://localhost/api/projects?category=Residential");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: { category: "Residential" },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual(residentialProjects);
+        expect(
+            body.every((project: ProjectApiResponse) => project.category === "Residential"),
+        ).toBe(true);
+    });
+
+    it("should return a list containing only the featured project", async () => {
+        const featuredProjects = mockProjects.filter(
+            (project: ProjectApiResponse) => project.featured,
+        );
+        (prisma.project.findMany as any).mockResolvedValue(featuredProjects);
+
+        const req = new Request("http://localhost/api/projects?featured=true");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: { featured: true },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body).toEqual(featuredProjects);
+        expect((body[0] as ProjectApiResponse).featured).toBe(true);
+        expect(body.length).toBe(1);
+    });
+
+    it("should return a list containing only the non-featured projects", async () => {
+        const nonFeaturedProjects = mockProjects.filter(
+            (project: ProjectApiResponse) => !project.featured,
+        );
+        (prisma.project.findMany as any).mockResolvedValue(nonFeaturedProjects);
+
+        const req = new Request("http://localhost/api/projects?featured=false");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: { featured: false },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body).toEqual(nonFeaturedProjects);
+        expect(body.every((project: ProjectApiResponse) => !project.featured)).toBe(true);
+        expect(body.length).toBe(mockProjects.length - 1);
+    });
+
+    it("should return a 500 error if the database query fails", async () => {
+        (prisma.project.findMany as any).mockRejectedValue(new Error("Database query failed"));
+
+        const req = new Request("http://localhost/api/projects");
+        const res = await GET(req);
+
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: "Failed to fetch projects" });
+    });
+
+    it("should return projects filtered by both category and featured", async () => {
+        const featuredResidentialProjects = mockProjects.filter(
+            (project: ProjectApiResponse) =>
+                project.category === "Residential" && project.featured === true,
+        );
+        (prisma.project.findMany as any).mockResolvedValue(featuredResidentialProjects);
+
+        const req = new Request(
+            "http://localhost/api/projects?category=Residential&featured=true",
+        );
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: { category: "Residential", featured: true },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body).toEqual(featuredResidentialProjects);
+        expect(body.every((project: ProjectApiResponse) => project.category === "Residential")).toBe(
+            true,
+        );
+        expect(body.every((project: ProjectApiResponse) => project.featured === true)).toBe(true);
+    });
+
+    it("should return an empty array when no projects match the filters", async () => {
+        (prisma.project.findMany as any).mockResolvedValue([]);
+
+        const req = new Request("http://localhost/api/projects?category=NonExistent");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: { category: "NonExistent" },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body).toEqual([]);
+        expect(Array.isArray(body)).toBe(true);
+    });
+
+    it("should treat invalid featured value as false", async () => {
+        const nonFeaturedProjects = mockProjects.filter(
+            (project: ProjectApiResponse) => !project.featured,
+        );
+        (prisma.project.findMany as any).mockResolvedValue(nonFeaturedProjects);
+
+        const req = new Request("http://localhost/api/projects?featured=invalid");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: { featured: false },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body).toEqual(nonFeaturedProjects);
+    });
+
+    it("should ignore empty category parameter", async () => {
+        (prisma.project.findMany as any).mockResolvedValue(mockProjects);
+
+        const req = new Request("http://localhost/api/projects?category=");
+        const res = await GET(req);
+
+        expect(prisma.project.findMany).toHaveBeenCalledWith({
+            where: {},
+            orderBy: { createdAt: "desc" },
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body).toEqual(mockProjects);
+    });
+});

--- a/src/app/api/projects/__tests__/post.test.ts
+++ b/src/app/api/projects/__tests__/post.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Tests for the `POST /api/projects` route handler.
+ *
+ * These integration-style tests focus on request validation, interaction with
+ * Prisma, and Cloudinary upload/cleanup behavior. We mock external services
+ * (auth, database, and Cloudinary) so that the tests can run deterministically
+ * without real network calls or a real database.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { prisma } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth-guards";
+import { uploadImage, deleteImage } from "@/lib/cloudinary";
+import type { ProjectApiResponse } from "@/types/project";
+
+// Mock auth guard used by the POST handler so we can simulate different
+// authorization outcomes (admin, non-admin, unauthenticated) in isolation.
+vi.mock("@/lib/auth-guards", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+// Mock the Prisma client so that route tests never depend on a live database.
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    project: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+// Mock Cloudinary helpers so tests avoid real image uploads/deletions and only
+// assert that the route calls them with the correct arguments.
+vi.mock("@/lib/cloudinary", () => ({
+  uploadImage: vi.fn(),
+  deleteImage: vi.fn(),
+}));
+
+describe("POST /api/projects", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("successfully creates a new project with a valid payload and no image", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    const createdProject: ProjectApiResponse = {
+      id: "proj_1",
+      title: "New Project",
+      description: "A brand new project",
+      category: "Residential",
+      featured: true,
+      imageUrl: null,
+      imagePublicId: null,
+      createdAt: "2026-02-12T10:00:00.000Z",
+      updatedAt: "2026-02-12T10:00:00.000Z",
+    };
+
+    (prisma.project.create as unknown as any).mockResolvedValue(createdProject);
+
+    const formData = new FormData();
+    // Intentionally include surrounding whitespace to verify trimming
+    formData.set("title", "   New Project   ");
+    formData.set("description", "A brand new project");
+    formData.set("category", "Residential");
+    formData.set("featured", "true");
+
+    const req = new Request("http://localhost/api/projects", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+
+    expect(requireAdmin).toHaveBeenCalledWith(req);
+
+    expect(prisma.project.create).toHaveBeenCalledWith({
+      data: {
+        title: "New Project",
+        description: "A brand new project",
+        category: "Residential",
+        featured: true,
+        imageUrl: null,
+        imagePublicId: null,
+      },
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual(createdProject);
+  });
+
+  it("successfully creates a new project with a valid jpeg image", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    const uploaded = {
+      publicId: "projects/img-123",
+      secureUrl: "https://res.cloudinary.com/demo/image/upload/v1/projects/img-123.jpg",
+      width: 1024,
+      height: 768,
+      format: "jpg",
+    };
+
+    (uploadImage as unknown as any).mockResolvedValue(uploaded);
+
+    const createdProject: ProjectApiResponse = {
+      id: "proj_img_1",
+      title: "Image Project",
+      description: "Project with a valid jpeg image",
+      category: "Residential",
+      featured: true,
+      imageUrl: uploaded.secureUrl,
+      imagePublicId: uploaded.publicId,
+      createdAt: "2026-02-12T12:00:00.000Z",
+      updatedAt: "2026-02-12T12:00:00.000Z",
+    };
+
+    (prisma.project.create as unknown as any).mockResolvedValue(createdProject);
+
+    class JpegFakeFile {
+      size: number;
+      type: string;
+      constructor(size: number, type: string) {
+        this.size = size;
+        this.type = type;
+      }
+      async arrayBuffer(): Promise<ArrayBuffer> {
+        return new ArrayBuffer(0);
+      }
+    }
+
+    const jpegFile = new JpegFakeFile(1024, "image/jpeg");
+
+    const originalFile = (globalThis as any).File;
+    (globalThis as any).File = JpegFakeFile as any;
+
+    const fakeFormData = {
+      get(key: string) {
+        switch (key) {
+          case "title":
+            return "Image Project";
+          case "description":
+            return "Project with a valid jpeg image";
+          case "category":
+            return "Residential";
+          case "featured":
+            return "true";
+          case "image":
+            return jpegFile;
+          default:
+            return null;
+        }
+      },
+    };
+
+    const req = {
+      formData: async () => fakeFormData,
+    } as unknown as Request;
+
+    const res = await POST(req);
+
+    (globalThis as any).File = originalFile;
+
+    expect(requireAdmin).toHaveBeenCalledWith(req as unknown as Request);
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+    expect(prisma.project.create).toHaveBeenCalledWith({
+      data: {
+        title: "Image Project",
+        description: "Project with a valid jpeg image",
+        category: "Residential",
+        featured: true,
+        imageUrl: uploaded.secureUrl,
+        imagePublicId: uploaded.publicId,
+      },
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual(createdProject);
+  });
+
+  it("successfully creates a new project when only title is provided", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    const createdProject: ProjectApiResponse = {
+      id: "proj_2",
+      title: "Title Only Project",
+      description: null,
+      category: null,
+      featured: false,
+      imageUrl: null,
+      imagePublicId: null,
+      createdAt: "2026-02-12T11:00:00.000Z",
+      updatedAt: "2026-02-12T11:00:00.000Z",
+    };
+
+    (prisma.project.create as unknown as any).mockResolvedValue(createdProject);
+
+    const formData = new FormData();
+    formData.set("title", "Title Only Project");
+
+    const req = new Request("http://localhost/api/projects", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+
+    expect(requireAdmin).toHaveBeenCalledWith(req);
+
+    expect(prisma.project.create).toHaveBeenCalledWith({
+      data: {
+        title: "Title Only Project",
+        description: null,
+        category: null,
+        featured: false,
+        imageUrl: null,
+        imagePublicId: null,
+      },
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual(createdProject);
+    expect("imageUrl" in body).toBe(true);
+    expect("imagePublicId" in body).toBe(true);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    const formData = new FormData();
+    // Intentionally do NOT set "title"
+    formData.set("description", "Missing title");
+
+    const req = new Request("http://localhost/api/projects", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+
+    expect(requireAdmin).toHaveBeenCalledWith(req);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Title is required" });
+  });
+
+  it("returns 400 when title is only whitespace", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    const formData = new FormData();
+    formData.set("title", "   "); // whitespace only
+    formData.set("description", "Whitespace title");
+
+    const req = new Request("http://localhost/api/projects", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+
+    expect(requireAdmin).toHaveBeenCalledWith(req);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Title is required" });
+  });
+
+  it("returns 401 when the session is missing or invalid", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: false,
+      session: null,
+      response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    });
+
+    const formData = new FormData();
+    formData.set("title", "Some Project");
+
+    const req = new Request("http://localhost/api/projects", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+
+    expect(requireAdmin).toHaveBeenCalledWith(req);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 403 when the user is authenticated but not an admin", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: false,
+      session: {},
+      response: new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }),
+    });
+
+    const formData = new FormData();
+    formData.set("title", "Some Project");
+
+    const req = new Request("http://localhost/api/projects", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+
+    expect(requireAdmin).toHaveBeenCalledWith(req);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Forbidden" });
+  });
+
+  it("returns 400 when image has an invalid svg mime type", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    class FakeFile {
+      size: number;
+      type: string;
+      constructor(size: number, type: string) {
+        this.size = size;
+        this.type = type;
+      }
+      async arrayBuffer(): Promise<ArrayBuffer> {
+        return new ArrayBuffer(0);
+      }
+    }
+
+    const svgFile = new FakeFile(10, "image/svg+xml");
+
+    const originalFile = (globalThis as any).File;
+    (globalThis as any).File = FakeFile as any;
+
+    const fakeFormData = {
+      get(key: string) {
+        switch (key) {
+          case "title":
+            return "Project With SVG Image";
+          case "description":
+            return "Has an invalid SVG image";
+          case "category":
+            return "Residential";
+          case "featured":
+            return "true";
+          case "image":
+            return svgFile;
+          default:
+            return null;
+        }
+      },
+    };
+
+    const req = {
+      formData: async () => fakeFormData,
+    } as unknown as Request;
+
+    const res = await POST(req);
+
+    // Restore original File constructor after the handler runs.
+    (globalThis as any).File = originalFile;
+
+    expect(requireAdmin).toHaveBeenCalledWith(req as unknown as Request);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({
+      error:
+        "Invalid image type. Allowed: image/jpeg, image/jpg, image/png, image/webp, image/gif",
+    });
+  });
+
+  it("returns 400 when image file is larger than 10MB", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    class LargeFakeFile {
+      size: number;
+      type: string;
+      constructor(size: number, type: string) {
+        this.size = size;
+        this.type = type;
+      }
+      async arrayBuffer(): Promise<ArrayBuffer> {
+        return new ArrayBuffer(0);
+      }
+    }
+
+    const largeFile = new LargeFakeFile(10 * 1024 * 1024 + 1, "image/jpeg");
+
+    const originalFile = (globalThis as any).File;
+    (globalThis as any).File = LargeFakeFile as any;
+
+    const fakeFormData = {
+      get(key: string) {
+        switch (key) {
+          case "title":
+            return "Project With Large Image";
+          case "description":
+            return "Has an oversized image";
+          case "category":
+            return "Residential";
+          case "featured":
+            return "true";
+          case "image":
+            return largeFile;
+          default:
+            return null;
+        }
+      },
+    };
+
+    const req = {
+      formData: async () => fakeFormData,
+    } as unknown as Request;
+
+    const res = await POST(req);
+
+    (globalThis as any).File = originalFile;
+
+    expect(requireAdmin).toHaveBeenCalledWith(req as unknown as Request);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "Image file is too large (max 10MB)",
+    });
+  });
+
+  it("returns 500 when Cloudinary upload fails", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    (uploadImage as unknown as any).mockRejectedValue(
+      new Error("Cloudinary upload failed"),
+    );
+
+    class FailingUploadFile {
+      size: number;
+      type: string;
+      constructor(size: number, type: string) {
+        this.size = size;
+        this.type = type;
+      }
+      async arrayBuffer(): Promise<ArrayBuffer> {
+        return new ArrayBuffer(0);
+      }
+    }
+
+    const jpegFile = new FailingUploadFile(1024, "image/jpeg");
+
+    const originalFile = (globalThis as any).File;
+    (globalThis as any).File = FailingUploadFile as any;
+
+    const fakeFormData = {
+      get(key: string) {
+        switch (key) {
+          case "title":
+            return "Project With Failing Upload";
+          case "description":
+            return "Cloudinary should fail during upload";
+          case "category":
+            return "Residential";
+          case "featured":
+            return "true";
+          case "image":
+            return jpegFile;
+          default:
+            return null;
+        }
+      },
+    };
+
+    const req = {
+      formData: async () => fakeFormData,
+    } as unknown as Request;
+
+    const res = await POST(req);
+
+    (globalThis as any).File = originalFile;
+
+    expect(requireAdmin).toHaveBeenCalledWith(req as unknown as Request);
+    expect(prisma.project.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Failed to create project" });
+  });
+
+  it("returns 500 and cleans up uploaded image when database create fails", async () => {
+    (requireAdmin as unknown as any).mockResolvedValue({
+      ok: true,
+      session: {},
+      response: null,
+    });
+
+    const uploaded = {
+      publicId: "projects/img-db-fail",
+      secureUrl: "https://res.cloudinary.com/demo/image/upload/v1/projects/img-db-fail.jpg",
+      width: 800,
+      height: 600,
+      format: "jpg",
+    };
+
+    (uploadImage as unknown as any).mockResolvedValue(uploaded);
+    (prisma.project.create as unknown as any).mockRejectedValue(
+      new Error("Database create failed"),
+    );
+
+    const deleteImageMock = deleteImage as unknown as ReturnType<typeof vi.fn>;
+
+    class DbFailFile {
+      size: number;
+      type: string;
+      constructor(size: number, type: string) {
+        this.size = size;
+        this.type = type;
+      }
+      async arrayBuffer(): Promise<ArrayBuffer> {
+        return new ArrayBuffer(0);
+      }
+    }
+
+    const jpegFile = new DbFailFile(1024, "image/jpeg");
+
+    const originalFile = (globalThis as any).File;
+    (globalThis as any).File = DbFailFile as any;
+
+    const fakeFormData = {
+      get(key: string) {
+        switch (key) {
+          case "title":
+            return "Project With DB Failure";
+          case "description":
+            return "DB create should fail after upload";
+          case "category":
+            return "Residential";
+          case "featured":
+            return "true";
+          case "image":
+            return jpegFile;
+          default:
+            return null;
+        }
+      },
+    };
+
+    const req = {
+      formData: async () => fakeFormData,
+    } as unknown as Request;
+
+    const res = await POST(req);
+
+    (globalThis as any).File = originalFile;
+
+    expect(requireAdmin).toHaveBeenCalledWith(req as unknown as Request);
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+    expect(prisma.project.create).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Failed to create project" });
+    expect(deleteImageMock).toHaveBeenCalledWith(uploaded.publicId);
+  });
+});

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -45,8 +45,7 @@ export async function GET(req: Request) {
     });
 
     return NextResponse.json(projects);
-  } catch (error) {
-    //console.error("Failed to fetch projects", error);
+  } catch {
     return NextResponse.json(
       { error: "Failed to fetch projects" },
       { status: 500 },
@@ -142,14 +141,16 @@ export async function POST(req: Request) {
 
     // 6. Return created project with 201 status
     return NextResponse.json(project, { status: 201 });
-  } catch (error) {
-    //console.error("Failed to create project", error);
-    // Best-effort cleanup of an image that was uploaded before the DB error occurred.
+  } catch {
+    // Clean up the uploaded image if create failed; surface failure to the client.
     if (uploadedPublicId) {
       try {
         await deleteImage(uploadedPublicId);
-      } catch (cleanupError) {
-        //console.error("Failed to cleanup uploaded image after DB error", cleanupError);
+      } catch {
+        return NextResponse.json(
+          { error: "Failed to create project; could not cleanup uploaded image" },
+          { status: 500 },
+        );
       }
     }
     return NextResponse.json(

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json(projects);
   } catch (error) {
-    console.error("Failed to fetch projects", error);
+    //console.error("Failed to fetch projects", error);
     return NextResponse.json(
       { error: "Failed to fetch projects" },
       { status: 500 },
@@ -143,7 +143,7 @@ export async function POST(req: Request) {
     // 6. Return created project with 201 status
     return NextResponse.json(project, { status: 201 });
   } catch (error) {
-    console.error("Failed to create project", error);
+    //console.error("Failed to create project", error);
     // Best-effort cleanup of an image that was uploaded before the DB error occurred.
     if (uploadedPublicId) {
       try {

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth-guards";
+import { uploadImage } from "@/lib/cloudinary";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const category = searchParams.get("category");
+    const featuredParam = searchParams.get("featured");
+
+    const where: {
+      category?: string;
+      featured?: boolean;
+    } = {};
+
+    if (category) {
+      where.category = category;
+    }
+
+    if (featuredParam !== null) {
+      where.featured = featuredParam === "true";
+    }
+
+    const projects = await prisma.project.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json({ data: projects });
+  } catch (error) {
+    console.error("Failed to fetch projects", error);
+    return NextResponse.json(
+      { error: "Failed to fetch projects" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  const adminResult = await requireAdmin();
+  if (!adminResult.ok) {
+    return adminResult.response;
+  }
+
+  try {
+    const formData = await req.formData();
+
+    const title = formData.get("title");
+    const description = formData.get("description");
+    const category = formData.get("category");
+    const featured = formData.get("featured");
+    const image = formData.get("image");
+
+    if (!title || typeof title !== "string") {
+      return NextResponse.json(
+        { error: "Title is required" },
+        { status: 400 },
+      );
+    }
+
+    let imageUrl: string | null = null;
+    let imagePublicId: string | null = null;
+
+    if (image instanceof File) {
+      if (!image.type.startsWith("image/")) {
+        return NextResponse.json(
+          { error: "Image must be of type image/*" },
+          { status: 400 },
+        );
+      }
+
+      // 5MB default limit
+      const maxSizeBytes = 5 * 1024 * 1024;
+      if (image.size > maxSizeBytes) {
+        return NextResponse.json(
+          { error: "Image file is too large (max 5MB)" },
+          { status: 400 },
+        );
+      }
+
+      const buffer = Buffer.from(await image.arrayBuffer());
+      const uploaded = await uploadImage(buffer);
+      imageUrl = uploaded.secureUrl;
+      imagePublicId = uploaded.publicId;
+    }
+
+    const project = await prisma.project.create({
+      data: {
+        title,
+        description: description && typeof description === "string"
+          ? description
+          : null,
+        category: category && typeof category === "string" ? category : null,
+        featured:
+          typeof featured === "string" ? featured === "true" : false,
+        imageUrl,
+        imagePublicId,
+      },
+    });
+
+    return NextResponse.json({ data: project }, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create project", error);
+    return NextResponse.json(
+      { error: "Failed to create project" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: Request) {
       where.category = category;
     }
 
-    if (featuredParam !== null) {
+    if (featuredParam !== null && featuredParam !== "") {
       where.featured = featuredParam === "true";
     }
 
@@ -149,7 +149,7 @@ export async function POST(req: Request) {
       try {
         await deleteImage(uploadedPublicId);
       } catch (cleanupError) {
-        console.error("Failed to cleanup uploaded image after DB error", cleanupError);
+        //console.error("Failed to cleanup uploaded image after DB error", cleanupError);
       }
     }
     return NextResponse.json(

--- a/src/lib/auth-guards.ts
+++ b/src/lib/auth-guards.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import type { Session } from "next-auth";
+import { auth } from "@/lib/auth";
+
+export type RequireAdminResult =
+  | {
+      ok: true;
+      session: Session;
+      response: null;
+    }
+  | {
+      ok: false;
+      session: null;
+      response: NextResponse;
+    };
+
+export async function requireAdmin(): Promise<RequireAdminResult> {
+  // Narrow the overloaded `auth` helper to its session-returning signature.
+  const session = (await auth()) as Session | null;
+
+  if (!session?.user?.isAdmin) {
+    return {
+      ok: false,
+      session: null,
+      response: NextResponse.json(
+        { error: "You must be an admin to perform this action." },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    session,
+    response: null,
+  };
+}
+

--- a/src/lib/auth-guards.ts
+++ b/src/lib/auth-guards.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { Session } from "next-auth";
 import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
 
 export type RequireAdminResult =
   | {
@@ -14,25 +15,177 @@ export type RequireAdminResult =
       response: NextResponse;
     };
 
-export async function requireAdmin(): Promise<RequireAdminResult> {
-  // Narrow the overloaded `auth` helper to its session-returning signature.
-  const session = (await auth()) as Session | null;
+/** Optional context for auth() so it can read cookies from the request (e.g. when called from API routes). */
+type AuthContext = { params?: Promise<Record<string, string>> | Record<string, string> };
 
-  if (!session?.user?.isAdmin) {
+/** Parse session token from request Cookie header (next-auth.session-token or __Secure- variant). */
+function getSessionTokenFromRequest(request: Request): string | null {
+  const cookieHeader = request.headers.get("cookie");
+  if (!cookieHeader) return null;
+  const match = cookieHeader.match(
+    /(?:^|;)\s*(?:next-auth\.session-token|__Secure-next-auth\.session-token)=([^;]+)/,
+  );
+  return match ? decodeURIComponent(match[1].trim()) : null;
+}
+
+/** Call auth with request/ctx so it reads the session cookie from the incoming request. */
+const getSession = async (
+  request?: Request,
+  ctx?: AuthContext,
+): Promise<Session | null> => {
+  if (request != null) {
+    return (await (auth as (req: Request, ctx?: AuthContext) => Promise<Session | null>)(request, ctx)) as Session | null;
+  }
+  return (await auth()) as Session | null;
+};
+
+export async function requireAdmin(
+  request?: Request,
+  ctx?: AuthContext,
+): Promise<RequireAdminResult> {
+  const session = await getSession(request, ctx);
+
+  if (!session) {
+    console.error("[requireAdmin] 401: no session (missing or invalid cookie)");
     return {
       ok: false,
       session: null,
       response: NextResponse.json(
-        { error: "You must be an admin to perform this action." },
-        { status: 403 },
+        { error: "Unauthorized" },
+        { status: 401 },
       ),
     };
   }
 
+  if (session.user?.isAdmin === true) {
+    return {
+      ok: true,
+      session,
+      response: null,
+    };
+  }
+
+  const userId = (session.user as { id?: string } | undefined)?.id;
+  if (userId) {
+    const dbUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { isAdmin: true },
+    });
+    if (dbUser?.isAdmin) {
+      return {
+        ok: true,
+        session,
+        response: null,
+      };
+    }
+  }
+
+  if (request) {
+    const sessionToken = getSessionTokenFromRequest(request);
+    if (sessionToken) {
+      const dbSession = await prisma.session.findUnique({
+        where: { sessionToken },
+        select: {
+          expires: true,
+          user: { select: { isAdmin: true } },
+        },
+      });
+      if (dbSession && dbSession.expires > new Date() && dbSession.user?.isAdmin) {
+        return {
+          ok: true,
+          session,
+          response: null,
+        };
+      }
+    }
+  }
+
+  console.error("[requireAdmin] 403: session exists but user is not admin", {
+    email: session.user?.email ?? "(no email)",
+    isAdmin: session.user?.isAdmin,
+    userId: userId ?? "(no id)",
+  });
   return {
-    ok: true,
-    session,
-    response: null,
+    ok: false,
+    session: null,
+    response: NextResponse.json(
+      { error: "Forbidden" },
+      { status: 403 },
+    ),
+  };
+}
+
+export type VerifyAdminResult =
+  | { ok: true; user: { isAdmin: true } }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Validates the request by checking the session and verifying isAdmin from the database.
+ * Use this for individual resource operations (e.g. PATCH/DELETE /api/projects/[id]).
+ * Pass the request (and optional ctx) so auth() can read the session cookie.
+ */
+export async function verifyAdmin(
+  request?: Request,
+  ctx?: AuthContext,
+): Promise<VerifyAdminResult> {
+  const session = await getSession(request, ctx);
+
+  if (!session) {
+    console.error("[verifyAdmin] 401: no session");
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  if (session.user?.email) {
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { isAdmin: true },
+    });
+    if (user?.isAdmin) {
+      return { ok: true, user: { isAdmin: true } };
+    }
+    console.error("[verifyAdmin] 403: user in DB is not admin", {
+      email: session.user.email,
+      dbIsAdmin: user?.isAdmin,
+    });
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  if (request) {
+    const sessionToken = getSessionTokenFromRequest(request);
+    if (sessionToken) {
+      const dbSession = await prisma.session.findUnique({
+        where: { sessionToken },
+        select: {
+          expires: true,
+          user: { select: { isAdmin: true } },
+        },
+      });
+      if (dbSession && dbSession.expires > new Date() && dbSession.user?.isAdmin) {
+        return { ok: true, user: { isAdmin: true } };
+      }
+      if (dbSession && !dbSession.user?.isAdmin) {
+        console.error("[verifyAdmin] 403: user in DB is not admin (from session lookup)");
+        return {
+          ok: false,
+          response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+        };
+      }
+    }
+  }
+
+  console.error("[verifyAdmin] 401: no email and no valid session token", {
+    hasSession: !!session,
+    hasEmail: !!session?.user?.email,
+  });
+  return {
+    ok: false,
+    response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
   };
 }
 

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,138 @@
+import { v2 as cloudinary } from "cloudinary";
+
+cloudinary.config({
+  secure: true,
+  // Credentials are read from process.env.CLOUDINARY_URL by default
+});
+
+export interface UploadResult {
+  publicId: string;
+  secureUrl: string;
+  width: number;
+  height: number;
+  format: string;
+}
+
+type UploadOptions = {
+  transformation?: object;
+  publicId?: string;
+  folder?: string;
+};
+
+export async function uploadImage(
+  file: string | Buffer,
+  options: UploadOptions = {},
+): Promise<UploadResult> {
+  const { transformation, publicId, folder = "projects" } = options;
+
+  if (typeof file === "string") {
+    try {
+      // Cloudinary supports regular URLs and base64 data URIs as the `file` argument.
+      const result = await cloudinary.uploader.upload(file, {
+        folder,
+        public_id: publicId,
+        transformation,
+        resource_type: "image",
+      });
+
+      return {
+        publicId: result.public_id,
+        secureUrl: result.secure_url,
+        width: result.width ?? 0,
+        height: result.height ?? 0,
+        format: result.format ?? "",
+      };
+    } catch (error) {
+      console.error("Failed to upload image to Cloudinary (string source)", error);
+      throw new Error("Failed to upload image to Cloudinary");
+    }
+  }
+
+  return new Promise<UploadResult>((resolve, reject) => {
+    const uploadStream = cloudinary.uploader.upload_stream(
+      {
+        folder,
+        public_id: publicId,
+        transformation,
+        resource_type: "image",
+      },
+      (error, result) => {
+        if (error || !result) {
+          console.error(
+            "Failed to upload image to Cloudinary (buffer source)",
+            error,
+          );
+          return reject(
+            error ?? new Error("Failed to upload image to Cloudinary"),
+          );
+        }
+
+        resolve({
+          publicId: result.public_id,
+          secureUrl: result.secure_url,
+          width: result.width ?? 0,
+          height: result.height ?? 0,
+          format: result.format ?? "",
+        });
+      },
+    );
+
+    uploadStream.end(file);
+  });
+}
+
+export async function deleteImage(publicId: string): Promise<void> {
+  if (!publicId) return;
+
+  await cloudinary.uploader.destroy(publicId, {
+    resource_type: "image",
+  });
+}
+
+export async function replaceProjectImage(
+  oldPublicId: string | null | undefined,
+  fileBuffer: Buffer,
+  options: Omit<UploadOptions, "publicId"> = {},
+): Promise<UploadResult> {
+  if (oldPublicId) {
+    try {
+      await deleteImage(oldPublicId);
+    } catch (error) {
+      // Log and continue; we still want to upload the new image
+      console.error("Failed to delete old Cloudinary image", error);
+    }
+  }
+
+  return uploadImage(fileBuffer, options);
+}
+
+type OptimizeOptions = {
+  width?: number;
+  height?: number;
+  crop?: string;
+  quality?: string | number;
+  format?: string;
+};
+
+export function getOptimizedImageUrl(
+  publicId: string,
+  options: OptimizeOptions = {},
+): string {
+  const { width, height, crop, quality, format } = options;
+
+  const transformation: Record<string, unknown> = {};
+
+  if (width !== undefined) transformation.width = width;
+  if (height !== undefined) transformation.height = height;
+  if (crop !== undefined) transformation.crop = crop;
+  if (quality !== undefined) transformation.quality = quality;
+  if (format !== undefined) transformation.fetch_format = format;
+
+  const hasTransformation = Object.keys(transformation).length > 0;
+
+  return cloudinary.url(publicId, {
+    secure: true,
+    transformation: hasTransformation ? [transformation] : undefined,
+  });
+}
+

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -106,6 +106,21 @@ export async function replaceProjectImage(
   return uploadImage(fileBuffer, options);
 }
 
+/** Matches cloudinary://API_KEY:API_SECRET@CLOUD_NAME */
+const CLOUDINARY_URL_REGEX = /^cloudinary:\/\/[^:]+:[^@]+@[a-zA-Z0-9_-]+$/;
+
+function assertCloudinaryUrlConfigured(): void {
+  const url = process.env.CLOUDINARY_URL;
+  if (!url || url.trim() === "") {
+    throw new Error("CLOUDINARY_URL is not set");
+  }
+  if (!CLOUDINARY_URL_REGEX.test(url.trim())) {
+    throw new Error(
+      "CLOUDINARY_URL has invalid format; expected cloudinary://API_KEY:API_SECRET@CLOUD_NAME",
+    );
+  }
+}
+
 type OptimizeOptions = {
   width?: number;
   height?: number;
@@ -118,6 +133,8 @@ export function getOptimizedImageUrl(
   publicId: string,
   options: OptimizeOptions = {},
 ): string {
+  assertCloudinaryUrlConfigured();
+
   const { width, height, crop, quality, format } = options;
 
   const transformation: Record<string, unknown> = {};

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,12 @@
+export interface ProjectApiResponse {
+  id: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  featured: boolean;
+  imageUrl: string | null;
+  imagePublicId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+

--- a/tests/projects-api.test.ts
+++ b/tests/projects-api.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+
+describe("projects API routes", () => {
+  it("has a placeholder test so the suite runs", () => {
+    expect(true).toBe(true);
+  });
+});
+

--- a/tests/projects-api.test.ts
+++ b/tests/projects-api.test.ts
@@ -1,8 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("projects API routes", () => {
-  it("has a placeholder test so the suite runs", () => {
-    expect(true).toBe(true);
-  });
-});
-


### PR DESCRIPTION
Closes #28 

# ✅ Test Coverage Summary

## POST `/api/projects` (11 tests)

- Creates project with valid payload (no image)
- Creates project with valid JPEG image
- Creates project when only `title` is provided
- Returns `400` when `title` is missing
- Returns `400` when `title` is only whitespace
- Returns `401` when session is missing or invalid
- Returns `403` when user is authenticated but not an admin
- Returns `400` for invalid image MIME type (e.g. SVG)
- Returns `400` when image file exceeds 10MB
- Returns `500` when Cloudinary upload fails
- Returns `500` and cleans up uploaded image if DB create fails

---

## GET `/api/projects` (9 tests)

- Returns all projects (no filters)
- Filters projects by `category`
- Returns only the featured project
- Returns only non-featured projects
- Returns `500` when database query fails
- Filters by both `category` and `featured`
- Returns empty array when no projects match filters
- Treats invalid `featured` value as `false`
- Ignores empty `category` parameter

---

## GET `/api/projects/[id]` (4 tests)

- Returns the correct project for an existing `id`
- Returns `404` when the project does not exist
- Returns `500` when the database query fails
- Returns `500` when the `params` promise rejects

---

## PATCH `/api/projects/[id]` (9 tests)

- Returns `200` with the updated project when update succeeds
- Returns `400` when `title` is missing from the payload
- Returns `400` when `title` is only whitespace
- Returns `400` when image file exceeds 10MB
- Returns `400` when image has an unsupported MIME type
- Returns `404` when the project does not exist
- Returns `401` when session is missing or invalid
- Returns `403` when user is authenticated but not an admin
- Returns `500` when a database error occurs

---

## DELETE `/api/projects/[id]` (5 tests)

- Deletes project from database and Cloudinary; second delete returns `404`
- Returns `404` when the project does not exist
- Returns `401` when session is missing or invalid
- Returns `403` when user is authenticated but not an admin
- Returns `500` when a database error occurs